### PR TITLE
Feature: Optional TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ All AWS clients are instantiated with credentials and a service endpoint. The de
 AWS.access_key_id = "AKIAOMGLOLWTFBBQ"
 AWS.secret_access_key = "this is a secret, don't tell anyone"
 AWS.region = "us-east-1"
+AWS.use_tls = "true"
 ```
-
-There is no global default endpoint since those are specific to the service. If you wish to use a nonstandard endpoint (for example, to use DigitalOcean Spaces or a MinIO instance instead of S3), you must set it when instantiating the client.
 
 To set the defaults via environment variables
 
@@ -39,6 +38,7 @@ To set the defaults via environment variables
 | `access_key_id` | `AWS_ACCESS_KEY_ID` |
 | `secret_access_key` | `AWS_SECRET_ACCESS_KEY` |
 | `region` | `AWS_REGION` |
+| `use_tls` | `AWS_USE_TLS` |
 
 Individual services and their APIs are documented below. All examples assume credentials are set globally and use default AWS endpoints for brevity.
 
@@ -68,6 +68,14 @@ s3.delete_object(bucket_name: "my-bucket", key: "my-object")
 
 # Pre-signed URLs for direct uploads or serving <img/> tags for user-uploaded objects
 s3.presigned_url("PUT", "my-bucket", "my-object", ttl: 10.minutes)
+```
+
+There is no global default endpoint since those are specific to the service. If you wish to use a nonstandard endpoint (for example, to use DigitalOcean Spaces or a MinIO instance instead of S3), you must set it when instantiating the client.
+
+### Custom endpoint
+
+```crystal
+s3 = AWS::S3::Client.new endpoint: URI.parse("http://localhost:4566")
 ```
 
 ### SNS

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: aws
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Jamie Gaskins <jgaskins@gmail.com>

--- a/src/aws.cr
+++ b/src/aws.cr
@@ -1,5 +1,5 @@
 module AWS
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 
   class_property access_key_id : String = ENV["AWS_ACCESS_KEY_ID"]? || ""
   class_property secret_access_key : String = ENV["AWS_SECRET_ACCESS_KEY"]? || ""

--- a/src/aws.cr
+++ b/src/aws.cr
@@ -4,9 +4,15 @@ module AWS
   class_property access_key_id : String = ENV["AWS_ACCESS_KEY_ID"]? || ""
   class_property secret_access_key : String = ENV["AWS_SECRET_ACCESS_KEY"]? || ""
   class_property region : String = ENV["AWS_REGION"]? || ""
+  class_property use_tls : Bool = case ENV["AWS_USE_TLS"]?
+  when "true"  then true
+  when "false" then false
+  else              true
+  end
 
   class Exception < ::Exception
   end
+
   class InvalidCredentials < Exception
   end
 end

--- a/src/aws.cr
+++ b/src/aws.cr
@@ -4,11 +4,7 @@ module AWS
   class_property access_key_id : String = ENV["AWS_ACCESS_KEY_ID"]? || ""
   class_property secret_access_key : String = ENV["AWS_SECRET_ACCESS_KEY"]? || ""
   class_property region : String = ENV["AWS_REGION"]? || ""
-  class_property use_tls : Bool = case ENV["AWS_USE_TLS"]?
-  when "true"  then true
-  when "false" then false
-  else              true
-  end
+  class_property use_tls : Bool = ENV["AWS_USE_TLS"] == "false" ? false : true
 
   class Exception < ::Exception
   end


### PR DESCRIPTION
In this PR:
1. An optional env `AWS_USE_TLS` to specify whether to use TLS or not. Defaults to true.